### PR TITLE
Modernize for PostgreSQL 10-18 (SCRAM auth, dynamic pidfile detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pm2-postgres
 PostgreSQL module for Keymetrics
 
-![pm2-postgres screenshot](https://raw.githubusercontent.com/pm2-hive/pm2-postgres/master/pm2-postgres.jpg)
+![pm2-postgres screenshot](https://raw.githubusercontent.com/vladonv/pm2-postgres/master/pm2-postgres.jpg)
 
 ## Description
 
@@ -16,15 +16,35 @@ PM2 module to monitor key PostgreSQL server metrics:
 
 ## Requirements
 
-This module requires a PostgreSQL install (v9.3+, including SCRAM-SHA-256 auth on PostgreSQL 10-17).
+This module requires a PostgreSQL install (v9.3+, including SCRAM-SHA-256 auth on PostgreSQL 10-18).
 
 ## Install
 
 ```bash
 $ npm install pm2 -g
 
-$ pm2 install pm2-postgres
+$ pm2 install @vladonv/pm2-postgres
 ```
+
+## Setting up a monitoring user
+
+Instead of using a superuser account, it's recommended to create a dedicated, restricted user for monitoring. Connect to your database as an administrator (`psql -U postgres`) and run:
+
+```sql
+-- 1. Create a dedicated monitoring user
+CREATE USER pm2_monitor WITH ENCRYPTED PASSWORD 'your_strong_password';
+
+-- 2. Allow it to connect to your specific database
+GRANT CONNECT ON DATABASE your_database_name TO pm2_monitor;
+
+-- 3. Grant the built-in role for reading system statistics. This is a safe,
+-- built-in role: it lets the user read system views (such as pg_stat_activity,
+-- pg_stat_database) to see connection counts, database load, and file sizes,
+-- without granting access to table data (no SELECT, INSERT, or DELETE on tables).
+GRANT pg_monitor TO pm2_monitor;
+```
+
+Then use `pm2_monitor` and its password as the `username`/`password` config values below.
 
 ## Config
 
@@ -37,17 +57,17 @@ The default connection details are :
 
 To modify the config values you can use the commands:
 ```bash
-$ pm2 set pm2-postgres:hostname localhost
-$ pm2 set pm2-postgres:port 5432
-$ pm2 set pm2-postgres:username guest
-$ pm2 set pm2-postgres:password guest
-$ pm2 set pm2-postgres:database postgres
+$ pm2 set @vladonv/pm2-postgres:hostname localhost
+$ pm2 set @vladonv/pm2-postgres:port 5432
+$ pm2 set @vladonv/pm2-postgres:username guest
+$ pm2 set @vladonv/pm2-postgres:password guest
+$ pm2 set @vladonv/pm2-postgres:database postgres
 ```
 
 ## Uninstall
 
 ```bash
-$ pm2 uninstall pm2-postgres
+$ pm2 uninstall @vladonv/pm2-postgres
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PM2 module to monitor key PostgreSQL server metrics:
 
 ## Requirements
 
-This module requires a PostgreSQL install (tested against v9.4).
+This module requires a PostgreSQL install (v9.3+, including SCRAM-SHA-256 auth on PostgreSQL 10-17).
 
 ## Install
 

--- a/app.js
+++ b/app.js
@@ -1,11 +1,29 @@
+var fs = require('fs');
+var path = require('path');
 var pmx = require('pmx');
 var pgClientFactory = require('./lib/clientFactory.js');
 var pgStats = require('./lib/stats.js');
 var pgActions = require('./lib/actions.js');
 
+// Debian/Ubuntu's postgresql-common names pidfiles "<version>-main.pid"
+// (e.g. "17-main.pid", "9.6-main.pid"). Scanning the directory instead of
+// hardcoding a version list keeps this working for future major versions.
+function detectPostgresPidPaths() {
+  var pgRunDir = '/var/run/postgresql';
+
+  try {
+    return fs.readdirSync(pgRunDir)
+      .filter(function (name) { return /^\d+(\.\d+)?-main\.pid$/.test(name); })
+      .sort(function (a, b) { return parseFloat(b) - parseFloat(a); })
+      .map(function (name) { return path.join(pgRunDir, name); });
+  } catch (e) {
+    return [];
+  }
+}
+
 pmx.initModule({
 
-  pid: pmx.resolvePidPaths(['/var/run/postgresql/9.4-main.pid', '/var/run/postgresql/9.3-main.pid', '/var/run/postgresql/9.5-main.pid']),
+  pid: pmx.resolvePidPaths(detectPostgresPidPaths()),
 
   // Options related to the display style on Keymetrics
   widget: {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,5 +1,4 @@
 var pmx = require('pmx');
-var _ = require('lodash');
 
 function initActions(pgClient) {
 
@@ -11,7 +10,7 @@ function initActions(pgClient) {
         return reply(err);
       }
 
-      reply(_.pluck(results.rows,'datname'));
+      reply(results.rows.map(function (row) { return row.datname; }));
     })
   });
 

--- a/lib/clientFactory.js
+++ b/lib/clientFactory.js
@@ -6,27 +6,21 @@ function build(conf) {
 
   var connectionString = "postgres://" + conf.username + ":" + conf.password + "@" + conf.hostname + ":" + conf.port + "/" + conf.database;
 
+  var pool = new pg.Pool({ connectionString: connectionString });
+
+  pool.on('error', function (err) {
+    // Errors on idle clients (e.g. connection dropped) must not crash the process.
+    pmx.notify("Postgres pool error: " + err);
+  });
+
   pgClient.query = function (queryString, cb) {
-    pg.connect(connectionString, function (err, client, done) {
+    pool.query(queryString, function (err, result) {
       if (err) {
-        // A connection error occurred, remove the client from the connection pool.
-        if (client) {
-          done(client);
-        }
-        return pmx.notify("Couldn't connect to postgres: " + err);
+        pmx.notify("Couldn't query postgres: " + err);
+        return cb(err);
       }
 
-      client.query(queryString, function (err, result) {
-        if (err) {
-          // return client to the connection pool
-          done();
-          return cb(err);
-        }
-
-        // return client to the connection pool
-        done();
-        return cb(null, result);
-      });
+      return cb(null, result);
     });
   };
 

--- a/lib/stats/refreshLockCount.js
+++ b/lib/stats/refreshLockCount.js
@@ -1,5 +1,9 @@
 var pmx = require('pmx');
-var _ = require('lodash');
+
+function findLockCount(rows, mode) {
+  var row = rows.find(function (row) { return row.mode === mode; });
+  return row ? row.count : 'N/A';
+}
 
 module.exports = function refreshLockCount(metrics, pgClient) {
   var queryString = "SELECT mode, count(mode) AS count FROM pg_locks GROUP BY mode ORDER BY mode;";
@@ -9,11 +13,9 @@ module.exports = function refreshLockCount(metrics, pgClient) {
     }
 
     // # of Access Share Locks
-    var accessShareLockCount = _.get(_.findWhere(results.rows, {mode: 'AccessShareLock'}), 'count', 'N/A');
-    metrics.accessShareLockCount.set(accessShareLockCount);
+    metrics.accessShareLockCount.set(findLockCount(results.rows, 'AccessShareLock'));
 
     // # of Exclusive Locks
-    var exclusiveLockCount = _.get(_.findWhere(results.rows, {mode: 'ExclusiveLock'}), 'count', 'N/A');
-    metrics.exclusiveLockCount.set(exclusiveLockCount);
+    metrics.exclusiveLockCount.set(findLockCount(results.rows, 'ExclusiveLock'));
   });
 };

--- a/lib/stats/refreshVersion.js
+++ b/lib/stats/refreshVersion.js
@@ -9,7 +9,7 @@ module.exports = function refreshVersion(metrics, pgClient) {
 
     // # of Indexes
     var fullVersion = results.rows[0].version;
-    var match = fullVersion.match(/^PostgreSQL (\d(?:(\.\d\d?)+))/);
+    var match = fullVersion.match(/^PostgreSQL (\d+(?:\.\d+)*)/);
     if (match) {
       metrics.version.set(match[1]);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pm2-postgres",
+  "name": "@vladonv/pm2-postgres",
   "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pm2-postgres",
+      "name": "@vladonv/pm2-postgres",
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,247 @@
+{
+  "name": "pm2-postgres",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pm2-postgres",
+      "version": "0.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "humanize": "0.0.9",
+        "pg": "^8.23.0",
+        "pmx": ">=0.5.5"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-metrics": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-metrics/-/deep-metrics-0.0.1.tgz",
+      "integrity": "sha512-732WmZgCWxOkf4QBvrCjPPuT6wTEzaGye/4JqYsU/sO0J53UNX4PBwK0JV262BZ5cxgLmKhU+NlrtKdPDgybkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/deep-metrics/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/humanize": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
+      "integrity": "sha512-bvZZ7vXpr1RKoImjuQ45hJb5OvE2oJafHysiD/AL3nkqTZH2hFCjQ3YZfCd63FefDitbJze/ispUPP0gfDsT2Q==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pmx": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/pmx/-/pmx-1.6.8.tgz",
+      "integrity": "sha512-ixb0R39fXfc1NXOv3EsRmkbYzrBYLaCitxq3qnenHQm8SHMncM/G9oqpnrbl0hHBTo9M0NZ50e+SY6WfIq8obg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "deep-metrics": "^0.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vladonv/pm2-postgres",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "PM2 PostgreSQL Module (fork of pm2-hive/pm2-postgres, updated for PostgreSQL 10-18 / SCRAM auth support)",
   "main": "app.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "pm2-postgres",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PM2 PostgreSQL Module",
   "main": "app.js",
   "dependencies": {
     "humanize": "0.0.9",
-    "lodash": "^3.10.1",
-    "pg": "^4.4.2",
+    "pg": "^8.23.0",
     "pmx": ">=0.5.5"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "pm2-postgres",
+  "name": "@vladonv/pm2-postgres",
   "version": "0.1.1",
-  "description": "PM2 PostgreSQL Module",
+  "description": "PM2 PostgreSQL Module (fork of pm2-hive/pm2-postgres, updated for PostgreSQL 10-18 / SCRAM auth support)",
   "main": "app.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "humanize": "0.0.9",
     "pg": "^8.23.0",
@@ -10,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pm2-hive/pm2-postgres.git"
+    "url": "git+https://github.com/vladonv/pm2-postgres.git"
   },
   "config": {
     "hostname": "localhost",
@@ -26,7 +29,7 @@
       "script": "app.js"
     }
   ],
-  "author": "Keymetrics Inc.",
+  "author": "Keymetrics Inc. (original), vladonv (fork maintainer)",
   "license": "MIT",
   "devDependencies": {}
 }


### PR DESCRIPTION
This module was last touched in 2016 and only tested against PostgreSQL 9.4. It no longer works against any current PostgreSQL install, mainly because it can't authenticate.

## Changes

- **`pg` 4 → 8**, and `lib/clientFactory.js` rewritten around `pg.Pool` instead of the old `pg.connect()` callback API. This is the important fix: `pg@4` predates SCRAM-SHA-256 support, which is the default password auth method since PostgreSQL 10. Without this the module simply can't connect to any modern install.
- Fixed the version-parsing regex in `lib/stats/refreshVersion.js` — it assumed the old `MAJOR.MINOR.PATCH` version string format and has silently never matched anything since PostgreSQL 10 switched to `MAJOR.MINOR`.
- Dropped the `lodash` dependency (`_.pluck`/`_.findWhere`/`_.get` → native `Array.map`/`Array.find`) — trivial usage, one less dependency to keep current.
- `app.js` no longer hardcodes a PID path list per PostgreSQL version (which stopped at 9.x). It now scans `/var/run/postgresql/*-main.pid` (the Debian/Ubuntu postgresql-common naming convention) so it keeps working for any future major version without further changes.
- Added `package-lock.json` for reproducible installs.

All the SQL queries themselves were already compatible with current PostgreSQL versions (checked against 17) — nothing in `pg_stat_activity`, `pg_locks`, `pg_class`, or `pg_stat_database` used here has changed. The connection/auth layer was the only thing actually broken.

Tested live against a real PostgreSQL 17 instance and confirmed working end-to-end (metrics reporting, actions, SCRAM auth).